### PR TITLE
chapter02: fix preamble typos in printargs family of programs

### DIFF
--- a/chapter02/printargs1.c
+++ b/chapter02/printargs1.c
@@ -1,11 +1,11 @@
 /*****************************************************************************
-  Title          : printargs.c
+  Title          : printargs1.c
   Author         : Stewart Weiss
   Created on     : January  9, 2023
   Description    : Shows how to access command-line arguments
   Purpose        :
-  Usage          : printargs <list of words>
-  Build with     : gcc -o printargs printargs.c
+  Usage          : printargs1 <list of words>
+  Build with     : gcc -o printargs1 printargs1.c
 
 ******************************************************************************
 * Copyright (C) 2025 - Stewart Weiss                                         *
@@ -26,7 +26,5 @@ int main(int argc, char *argv[])
     for ( int i = 1; i < argc ; i++ ){
          printf("%d: %s\n", i, argv[i]);
     }
-
-    printf("\n");
     return 0;
 }

--- a/chapter02/printargs3.c
+++ b/chapter02/printargs3.c
@@ -1,11 +1,11 @@
 /*****************************************************************************
-  Title          : printargs2.c
+  Title          : printargs3.c
   Author         : Stewart Weiss
   Created on     : January  9, 2023
-  Description    : Shows a second way to access command-line arguments
+  Description    : Shows a third way to access command-line arguments
   Purpose        :
-  Usage          : printargs2 <list of words>
-  Build with     : gcc -o printargs2 printargs2.c
+  Usage          : printargs3 <list of words>
+  Build with     : gcc -o printargs3 printargs3.c
 
 ******************************************************************************
 * Copyright (C) 2025 - Stewart Weiss                                         *


### PR DESCRIPTION
Additionally, removed an unecessary print from printargs1.c. It looks like you may have started by separating the arguments with a single space, which is why you needed the print at the end. But now it just leaves an extra blank line, and is inconsistent with the output of printargs2 and printargs3.