### PR TITLE
chapter02, getopt_demo.c: whitespace is not allowed before optional argument

### DIFF
--- a/chapter02/getopt_demo.c
+++ b/chapter02/getopt_demo.c
@@ -9,7 +9,7 @@
   Usage          : getopt_demo
                    with any options following it, but the ones recognized are:
                         -h
-                        -b [optional_arg]
+                        -b[optional_arg]
                         -c required_arg
                         -1
                     and any number of arguments after them


### PR DESCRIPTION
This is really subtle, but I think technically something misleading in the preamble. Quoth `man getopt` on my system:

> A simple short option is a '-' followed by a short option character. If the
> option has a required argument, it may be written directly after the option
> character or as the next parameter (i.e., separated by whitespace on the
> command line). **If the option has an optional argument, it must be written
> directly after the option character if present.**

This means `./getopt_demo -b hello` is not doing what one would expect / is incorrect usage. Indeed, it prints:

> Options found:
> -b with no argument
> non-option ARGV-elements:
> hello

The only acceptable form is `./getopt_demo -bhello`... thanks getopt! I'm not sure if removing the whitespace from the preamble's usage directions will suffice, or if it's relevant enough to point out explicitly.